### PR TITLE
The MySQL.Results class now handles NULL values in the result set

### DIFF
--- a/Sources/MySQL/MySQL.swift
+++ b/Sources/MySQL/MySQL.swift
@@ -498,7 +498,7 @@ public final class MySQL {
 	public final class Results: IteratorProtocol {
 		var ptr: UnsafeMutablePointer<MYSQL_RES>?
 		
-		public typealias Element = [String]
+		public typealias Element = [String?]
 		
 		init(_ ptr: UnsafeMutablePointer<MYSQL_RES>) {
 			self.ptr = ptr
@@ -548,7 +548,7 @@ public final class MySQL {
 			}
 		#endif
 			
-			var ret = [String]()
+			var ret = [String?]()
 			for fieldIdx in 0..<self.numFields() {
 				let length = lengths[fieldIdx]
 				let rowVal = row[fieldIdx]
@@ -557,13 +557,17 @@ public final class MySQL {
 				if let raw = UnsafeMutablePointer<UInt8>(rowVal) {
 					let s = UTF8Encoding.encode(generator: GenerateFromPointer(from: raw, count: len))
 					ret.append(s)
-				}
+                } else {
+                    ret.append(nil)
+                }
 			#else
 				let raw = UnsafeMutablePointer<UInt8>(rowVal)
 				if nil != raw {
 					let s = UTF8Encoding.encode(generator: GenerateFromPointer(from: raw, count: len))
 					ret.append(s)
-				}
+                } else {
+                    ret.append(nil)
+                }
 			#endif
 			}
 			return ret

--- a/Sources/MySQLTests/MySQLTests.swift
+++ b/Sources/MySQLTests/MySQLTests.swift
@@ -186,6 +186,41 @@ class MySQLTests: XCTestCase {
 		let list2 = mysql.listTables(wildcard: "test")
 		XCTAssert(list2.count == 0)
 	}
+    
+    func testInsertNull() {
+        mysql.query(statement: "DROP TABLE IF EXISTS test")
+        
+        let qres = mysql.query(statement: "CREATE TABLE test (id INT, d DOUBLE, s VARCHAR(1024))")
+        XCTAssert(qres == true, mysql.errorMessage())
+        
+        let list = mysql.listTables(wildcard: "test")
+        XCTAssert(list.count > 0)
+        
+        let ires = mysql.query(statement: "INSERT INTO test (id,d,s) VALUES (1,NULL,\"Row 1\")")
+        XCTAssert(ires == true, mysql.errorMessage())
+        
+        let sres2 = mysql.query(statement: "SELECT id,d,s FROM test")
+        XCTAssert(sres2 == true, mysql.errorMessage())
+        
+        let results = mysql.storeResults()!
+        XCTAssert(results.numRows() == 1)
+        XCTAssert(results.numFields() == 3)
+        
+        results.forEachRow { row in
+            XCTAssert(row.count == 3)
+            XCTAssertEqual(row[0], "1")
+            XCTAssertNil(row[1])
+            XCTAssertEqual(row[2], "Row 1")
+        }
+        
+        results.close()
+        
+        let qres2 = mysql.query(statement: "DROP TABLE test")
+        XCTAssert(qres2 == true, mysql.errorMessage())
+        
+        let list2 = mysql.listTables(wildcard: "test")
+        XCTAssert(list2.count == 0)
+    }
 	
 	func testQueryStmt1() {
 		mysql.query(statement: "DROP TABLE IF EXISTS all_data_types")


### PR DESCRIPTION
The `String` array now includes nil values

`Element` has thus been changed from a `[String]` to a `[String?]` alias

Fixes issue https://github.com/PerfectlySoft/Perfect-MySQL/issues/6
