### PR TITLE
Make public attributes in struct FieldInfo

### DIFF
--- a/Sources/MySQL/MySQL.swift
+++ b/Sources/MySQL/MySQL.swift
@@ -531,8 +531,8 @@ public final class MySQLStmt {
 	}
 	
 	public struct FieldInfo {
-		let name: String
-		let type: FieldType
+		public let name: String
+		public let type: FieldType
 	}
 	
 	public func fieldInfo(index: Int) -> FieldInfo? {


### PR DESCRIPTION
It does not make sense to share a structure and keep its attributes private.

Making public this fields we can get the field names.