### PR TITLE
Adding ping()

### DIFF
--- a/Sources/PerfectMySQL.swift
+++ b/Sources/PerfectMySQL.swift
@@ -141,6 +141,14 @@ public final class MySQL {
 	deinit {
 		self.close()
 	}
+
+  public func ping() -> Bool {
+    if let ref = ptr, 0 == mysql_ping(ref) {
+      return true
+    } else {
+      return false
+    }
+  }
 	
     /// Close connection and set ptr to nil
 	public func close() {

--- a/Tests/PerfectMySQLTests/MySQLTests.swift
+++ b/Tests/PerfectMySQLTests/MySQLTests.swift
@@ -744,8 +744,17 @@ class PerfectMySQLTests: XCTestCase {
 }
 
 extension PerfectMySQLTests {
+  func testPing() {
+    XCTAssertTrue(mysql.ping())
+    mysql.close()
+    XCTAssertFalse(mysql.ping())
+  }
+}
+
+extension PerfectMySQLTests {
     static var allTests : [(String, (PerfectMySQLTests) -> () throws -> ())] {
         return [
+                   ("testPing", testPing),
                    ("testConnect", testConnect),
                    ("testListDbs1", testListDbs1),
                    ("testListDbs2", testListDbs2),


### PR DESCRIPTION
MySQL connection will go away when idle timeout. The ping() function
can confirm the connectivity and also reconnect if need.
https://dev.mysql.com/doc/refman/5.7/en/mysql-ping.html
Thanks @JoeCharlier.