### PR TITLE
Add support for mysql_set_server_option

### DIFF
--- a/Sources/PerfectMySQL/MySQL.swift
+++ b/Sources/PerfectMySQL/MySQL.swift
@@ -217,18 +217,18 @@ public final class MySQL {
 			return MYSQL_ENABLE_CLEARTEXT_PLUGIN
 		case MySQLOpt.MYSQL_OPT_CAN_HANDLE_EXPIRED_PASSWORDS:
 			return MYSQL_OPT_CAN_HANDLE_EXPIRED_PASSWORDS
-        }
-    }
-    
-    func exposedOptionToMySQLServerOption(_ o: MySQLServerOpt) -> enum_mysql_set_option {
-        switch o {
-        case MySQLServerOpt.MYSQL_OPTION_MULTI_STATEMENTS_ON:
-            return MYSQL_OPTION_MULTI_STATEMENTS_ON
-        case MySQLServerOpt.MYSQL_OPTION_MULTI_STATEMENTS_OFF:
-            return MYSQL_OPTION_MULTI_STATEMENTS_OFF
-        }
-    }
-	
+		}
+	}
+
+	func exposedOptionToMySQLServerOption(_ o: MySQLServerOpt) -> enum_mysql_set_option {
+		switch o {
+		case MySQLServerOpt.MYSQL_OPTION_MULTI_STATEMENTS_ON:
+			return MYSQL_OPTION_MULTI_STATEMENTS_ON
+		case MySQLServerOpt.MYSQL_OPTION_MULTI_STATEMENTS_OFF:
+			return MYSQL_OPTION_MULTI_STATEMENTS_OFF
+		}
+	}
+
 	/// Sets connect options for connect()
 	@discardableResult
 	public func setOption(_ option: MySQLOpt) -> Bool {
@@ -258,12 +258,12 @@ public final class MySQL {
 		}
 		return b
 	}
-    
-    /// Sets connect options after connect()
-    @discardableResult
-    public func setServerOption(_ option: MySQLServerOpt) -> Bool {
-        return mysql_set_server_option(mysqlPtr, exposedOptionToMySQLServerOption(option)) == 0
-    }
+	
+	/// Sets connect options after connect()
+	@discardableResult
+	public func setServerOption(_ option: MySQLServerOpt) -> Bool {
+		return mysql_set_server_option(mysqlPtr, exposedOptionToMySQLServerOption(option)) == 0
+	}
 	
 	/// Class used to manage and interact with result sets
 	public final class Results: IteratorProtocol {

--- a/Sources/PerfectMySQL/MySQL.swift
+++ b/Sources/PerfectMySQL/MySQL.swift
@@ -259,7 +259,7 @@ public final class MySQL {
 		return b
 	}
 	
-	/// Sets connect options after connect()
+	/// Sets server option (must be set after connect() is called)
 	@discardableResult
 	public func setServerOption(_ option: MySQLServerOpt) -> Bool {
 		return mysql_set_server_option(mysqlPtr, exposedOptionToMySQLServerOption(option)) == 0

--- a/Sources/PerfectMySQL/MySQL.swift
+++ b/Sources/PerfectMySQL/MySQL.swift
@@ -217,8 +217,17 @@ public final class MySQL {
 			return MYSQL_ENABLE_CLEARTEXT_PLUGIN
 		case MySQLOpt.MYSQL_OPT_CAN_HANDLE_EXPIRED_PASSWORDS:
 			return MYSQL_OPT_CAN_HANDLE_EXPIRED_PASSWORDS
-		}
-	}
+        }
+    }
+    
+    func exposedOptionToMySQLServerOption(_ o: MySQLServerOpt) -> enum_mysql_set_option {
+        switch o {
+        case MySQLServerOpt.MYSQL_OPTION_MULTI_STATEMENTS_ON:
+            return MYSQL_OPTION_MULTI_STATEMENTS_ON
+        case MySQLServerOpt.MYSQL_OPTION_MULTI_STATEMENTS_OFF:
+            return MYSQL_OPTION_MULTI_STATEMENTS_OFF
+        }
+    }
 	
 	/// Sets connect options for connect()
 	@discardableResult
@@ -249,6 +258,12 @@ public final class MySQL {
 		}
 		return b
 	}
+    
+    /// Sets connect options after connect()
+    @discardableResult
+    public func setServerOption(_ option: MySQLServerOpt) -> Bool {
+        return mysql_set_server_option(mysqlPtr, exposedOptionToMySQLServerOption(option)) == 0
+    }
 	
 	/// Class used to manage and interact with result sets
 	public final class Results: IteratorProtocol {

--- a/Sources/PerfectMySQL/PerfectMySQL.swift
+++ b/Sources/PerfectMySQL/PerfectMySQL.swift
@@ -111,7 +111,7 @@ public enum MySQLOpt {
 	MYSQL_OPT_CAN_HANDLE_EXPIRED_PASSWORDS
 }
 
-/// enum for mysql options
+/// enum for mysql server options
 public enum MySQLServerOpt {
     case MYSQL_OPTION_MULTI_STATEMENTS_ON, MYSQL_OPTION_MULTI_STATEMENTS_OFF
 }

--- a/Sources/PerfectMySQL/PerfectMySQL.swift
+++ b/Sources/PerfectMySQL/PerfectMySQL.swift
@@ -111,4 +111,8 @@ public enum MySQLOpt {
 	MYSQL_OPT_CAN_HANDLE_EXPIRED_PASSWORDS
 }
 
+/// enum for mysql options
+public enum MySQLServerOpt {
+    case MYSQL_OPTION_MULTI_STATEMENTS_ON, MYSQL_OPTION_MULTI_STATEMENTS_OFF
+}
 


### PR DESCRIPTION
Added support for `mysql_set_server_option`

Example: 
```Swift
let mysql = MySQL()
mysql.connect(host: host, user: username, password: password, db: database)
mysql.setServerOption(.MYSQL_OPTION_MULTI_STATEMENTS_ON)
let sql = """
  INSERT INTO test (field1, field2)
  VALUES ("Hello", "World");
  INSERT INTO test (field1, field2)
  VALUES ("World", "Hello");
"""
mysql.query(statement: sql) 
```

If `MYSQL_OPTION_MULTI_STATEMENTS_ON` is not set (or `MYSQL_OPTION_MULTI_STATEMENTS_OFF` is set again) this sql will throw an error as usual.

This feature allows for example the creation of `TRIGGER`s in Perfect-MySQL 