### PR TITLE
Added Int32 decoding

### DIFF
--- a/Sources/PerfectMySQL/MySQLCRUD.swift
+++ b/Sources/PerfectMySQL/MySQLCRUD.swift
@@ -58,8 +58,8 @@ class MySQLCRUDRowReader<K : CodingKey>: KeyedDecodingContainerProtocol {
 		switch a {
 		case let i as Int64:
 			return Int(i)
-        case let i as Int32:
-            return Int(i)
+		case let i as Int32:
+			return Int(i)
 		case let i as Int:
 			return i
 		default:

--- a/Sources/PerfectMySQL/MySQLCRUD.swift
+++ b/Sources/PerfectMySQL/MySQLCRUD.swift
@@ -58,6 +58,8 @@ class MySQLCRUDRowReader<K : CodingKey>: KeyedDecodingContainerProtocol {
 		switch a {
 		case let i as Int64:
 			return Int(i)
+        case let i as Int32:
+            return Int(i)
 		case let i as Int:
 			return i
 		default:


### PR DESCRIPTION
Swift documentation says 

> On 32-bit platforms, Int is the same size as Int32, and on 64-bit platforms, Int is the same size as Int64.

The actual code in the Int decode method is 
```swift
switch a {
case let i as Int64:
    return Int(i)
case let i as Int:
    return i
default:
    throw MySQLCRUDError("Could not convert \(String(describing: a)) into an Int.")
}
```

When working on a 64-bit platform, the two first switch cases are equivalent and if `a: Int32`, an exception will be thrown.

The pull request adds a case for `a: Int32` to ensure correct behavior when receiving a 32-bit Int on a 64-bit machine.