### PR TITLE
Update MySQLStmt.swift : Fixing leaks

### DIFF
--- a/Sources/PerfectMySQL/MySQLStmt.swift
+++ b/Sources/PerfectMySQL/MySQLStmt.swift
@@ -808,6 +808,7 @@ public final class MySQLStmt {
 				}
 				binds.advanced(by: i).initialize(to: bind)
 			}
+			free(scratch)
 			mysql_stmt_bind_result(stmt.ptr, binds)
 		}
 		


### PR DESCRIPTION
At line 756 the "scratch" reference is allocated but never free so it create a memory leaks for each myslq statement