### PR TITLE
Added missing autocommit call.

### DIFF
--- a/Sources/PerfectMySQL/MySQL.swift
+++ b/Sources/PerfectMySQL/MySQL.swift
@@ -97,7 +97,12 @@ public final class MySQL {
 		}
 		return result
 	}
-	
+
+	/// If false it starts transaction which can be rolled back
+	public func autocommit(_ autocommit: Bool) -> Bool {
+		return 1 == mysql_autocommit(mysqlPtr, autocommit ? 1 : 0)
+	}
+
 	/// Commits the transaction
 	public func commit() -> Bool {
 		return 1 == mysql_commit(mysqlPtr)


### PR DESCRIPTION
Added missing autocommit call to MySQL wrapper.

Without this you can't start transactions which can be rolled back, which I think it is important for integrity of the database especially on the server side.