### PR TITLE
Fixed incorrect binary field check

### DIFF
--- a/Sources/PerfectMySQL/MySQLStmt.swift
+++ b/Sources/PerfectMySQL/MySQLStmt.swift
@@ -100,7 +100,7 @@ public final class MySQLStmt {
 			 MYSQL_TYPE_MEDIUM_BLOB,
 			 MYSQL_TYPE_LONG_BLOB,
 			 MYSQL_TYPE_BLOB:
-			if (field.pointee.flags & UInt32(BINARY_FLAG)) != 0 {
+			if field.pointee.charsetnr == 63 /* binary */ {
 				return .bytes
 			}
 			fallthrough
@@ -577,7 +577,7 @@ public final class MySQLStmt {
 				 MYSQL_TYPE_MEDIUM_BLOB,
 				 MYSQL_TYPE_LONG_BLOB,
 				 MYSQL_TYPE_BLOB:
-				if ( (field.pointee.flags & UInt32(BINARY_FLAG)) != 0) {
+				if field.pointee.charsetnr == 63 /* binary */ {
 					return .bytes(type)
 				}
 				fallthrough


### PR DESCRIPTION
`BINARY_FLAG` is used to check for the `BINARY` _attribute_, [as noted in the documentation](https://dev.mysql.com/doc/refman/5.7/en/c-api-data-structures.html):

> Flag Value | Flag Description
> -- | --
> `BINARY_FLAG` | Field has the BINARY attribute

The `BINARY` attribute is not the same thing as the `BINARY` _type_. The attribute is just to do with collation, as noted [here](https://dev.mysql.com/doc/refman/5.7/en/binary-varbinary.html):

> The `BINARY` and `VARBINARY` data types are distinct from the `CHAR BINARY` and `VARCHAR BINARY` data types. For the latter types, the `BINARY` attribute does not cause the column to be treated as a binary string column. Instead, it causes the binary (`_bin`) collation for the column character set to be used, and the column itself contains nonbinary character strings rather than binary byte strings. For example, `CHAR(5) BINARY` is treated as `CHAR(5) CHARACTER SET latin1 COLLATE latin1_bin`, assuming that the default character set is `latin1`. This differs from `BINARY(5)`, which stores 5-bytes binary strings that have the `binary` character set and collation.

The correct way to check for binary data is to use `charsetnr` as described [here](https://dev.mysql.com/doc/refman/5.7/en/c-api-data-structures.html):

> To distinguish between binary and nonbinary data for string data types, check whether the `charsetnr` value is 63. If so, the character set is `binary`, which indicates binary rather than nonbinary data. This enables you to distinguish `BINARY` from `CHAR`, `VARBINARY` from `VARCHAR`, and the `BLOB` types from the `TEXT` types. 

This caused issues in MariaDB, particularly with a nested Codable. See PerfectlySoft/Perfect-MariaDB#4.

