### PR TITLE
Relax strictness on decoding to Int from different integer widths

### DIFF
--- a/Sources/PerfectMySQL/MySQLCRUD.swift
+++ b/Sources/PerfectMySQL/MySQLCRUD.swift
@@ -60,10 +60,14 @@ class MySQLCRUDRowReader<K : CodingKey>: KeyedDecodingContainerProtocol {
 			return Int(i)
 		case let i as Int32:
 			return Int(i)
+		case let i as Int16:
+			return Int(i)
+		case let i as Int8:
+			return Int(i)
 		case let i as Int:
 			return i
 		default:
-			throw MySQLCRUDError("Could not convert \(String(describing: a)) into an Int.")
+			throw MySQLCRUDError("Could not convert \(String(describing: a)) into an Int for key: \(key.stringValue)")
 		}
 	}
 	func decode(_ type: Int8.Type, forKey key: Key) throws -> Int8 {
@@ -83,10 +87,16 @@ class MySQLCRUDRowReader<K : CodingKey>: KeyedDecodingContainerProtocol {
 		switch a {
 		case let i as UInt64:
 			return UInt(i)
+		case let i as UInt32:
+			return UInt(i)
+		case let i as UInt16:
+			return UInt(i)
+		case let i as UInt8:
+			return UInt(i)
 		case let i as UInt:
 			return i
 		default:
-			throw MySQLCRUDError("Could not convert \(String(describing: a)) into an UInt.")
+			throw MySQLCRUDError("Could not convert \(String(describing: a)) into an UInt for key: \(key.stringValue)")
 		}
 	}
 	func decode(_ type: UInt8.Type, forKey key: Key) throws -> UInt8 {

--- a/Tests/PerfectMySQLTests/PerfectMySQLTests.swift
+++ b/Tests/PerfectMySQLTests/PerfectMySQLTests.swift
@@ -1676,6 +1676,25 @@ class PerfectMySQLTests: XCTestCase {
 			XCTFail("\(error)")
 		}
 	}
+
+	func testIntConversion() {
+		do {
+			let db = try getTestDB()
+			struct IntTest: Codable {
+				let id: Int
+			}
+			try db.sql("CREATE TABLE IntTest(id tinyint PRIMARY KEY)")
+			let table = db.table(IntTest.self)
+			let inserted = IntTest(id: 1)
+			try table.insert(inserted)
+			guard let selected = try db.table(IntTest.self).where(\IntTest.id == 1).first() else {
+				return XCTFail("Unable to find IntTest.")
+			}
+			XCTAssertEqual(selected.id, inserted.id)
+		} catch {
+			XCTFail("\(error)")
+		}
+	}
 	
 	func testBespokeSQL() {
 		do {


### PR DESCRIPTION
This is mostly for when you are working with tables not created by Perfect-CRUD. Tables created with Perfect-CRUD are not affected by this pull request.

The scenario I am talking about is if another application created a database which, say, looked like this:
```sql
CREATE TABLE Example(
    id TINYINT PRIMARY KEY
);
```

and you had a Swift class that looked like this:

```swift
struct Example {
    let id: Int
}
```

Previously, this would error upon reading from the table as Perfect-MySQL _required_ you to declare `id` as Int8. I have relaxed the restriction so that Int can be used on integer width used by the database. If you want stricter enforcement, you can still use the fixed-width Int8-Int64 types.

Why do this? There are many reasons:

* Interoperability
  - Swift is strict about types - different width integers do not implicitly convert between each other. As such it is common practice to _always_ use Int regardless of the width required in order to increase interoperability between code, so that you don't need type conversions everywhere when interacting with the standard library or some framework.
  - It is recommended to use Int everywhere in the [official documentation](https://docs.swift.org/swift-book/LanguageGuide/TheBasics.html):
    > Unless you need to work with a specific size of integer, always use Int for integer values in your code. This aids code consistency and interoperability.
  - The change also means it is more likely to be compatible with existing data models without having to modify them.
* Int is variable
  - Int is not exactly what you would describe as a "fixed-width integer". The width varies between platforms depending on the native word size.
  - Therefore enforcing it to match a database integer width (which is likely fixed-width) makes little sense.
  - Int can be 32-bit or 64-bit depending on the platform. There already had to be changes (#43) to support this. We might as well go further than something inbetween and make it cover all widths.

There's many more reasons I can go into if you want to discuss it further.

In summary:
* Int has been relaxed to now cover _all_ supported integer widths.
* Fixed-with integers (Int8-Int64) remain untouched and are restricted to match the database field's integer width as before.

A test case is supplied.

Next Steps?
* Add this to MariaDB
  - This is done (it's a straight-up copy-paste job) but I've not submitted it until I hear the outcome of this pull request.
* Support interoperability between UInt and Int?
  - Another piece of guidance given by Swift is to prefer `Int` over `UInt`, so it is perhaps a good idea to allow conversions from UInt8-UInt64 to Int.